### PR TITLE
Add NLog support for Intacct SDK to log to

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ The Sql Provider expects that the system is run on a Sql Server that holds both 
 ## Other Aspects
 
 There are several other aspects which have been added for various clients, etc.  These include 'Statistic Journals' and 'Expense Journals' that will transfer Staff Hours and Staff Expenses to the GL system.
+
+### Logging
+
+Basic logging is enabled through ASP.NET appsettings.json values per Microsoft's [Logging Documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-2.1&tabs=aspnetcore2x#log-filtering).  Standard logging is all sent to the Server's EventLog / EventViewer.
+
+Intacct logging is available by configuring the [NLog.config](https://github.com/nlog/nlog/wiki/Configuration-file) file (set the intacctfile path to a writable location).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 General Ledger Integration with Practice Engine
 
+[![Build Status](https://praceng.visualstudio.com/_apis/public/build/definitions/5ab340ff-723c-45a6-bf17-a12ca818093a/91/badge)](https://praceng.visualstudio.com/Nominal%20Ledger/_build/index?definitionId=91)
+
 ## Overview
 
 The GL Integration works by providing a set of Nominal Ledger tables that map our single-entry accounting system into a double-entry system.  Once the double entry values are created, the system (this project) has a GL Provider that is mapped to a GL System, where it queries for Account Types and Accounts which create a set of mappings.

--- a/src/PE.Nominal.Intacct/IntacctBaseService.cs
+++ b/src/PE.Nominal.Intacct/IntacctBaseService.cs
@@ -15,6 +15,7 @@ namespace PE.Nominal.Intacct
     {
         private readonly IHostingEnvironment _env;
         protected readonly IntacctConfig _config;
+
         public IntacctBaseService(IntacctConfig config, IHostingEnvironment env)
         {
             _config = config;
@@ -69,7 +70,8 @@ namespace PE.Nominal.Intacct
                 SenderPassword = orgConfig.SenderPassword,
                 CompanyId = orgConfig.CompanyID,
                 UserId = orgConfig.UserID,
-                UserPassword = orgConfig.UserPassword
+                UserPassword = orgConfig.UserPassword,
+                Logger = NLog.LogManager.GetLogger("Intacct")
             });
 
             return intacctClient;

--- a/src/PE.Nominal.Web/NLog.config
+++ b/src/PE.Nominal.Web/NLog.config
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      autoReload="true"
+      internalLogLevel="info"
+      internalLogFile="c:\temp\internal-nlog.txt">
+
+  <!-- enable asp.net core layout renderers -->
+  <extensions>
+    <add assembly="NLog.Web.AspNetCore"/>
+  </extensions>
+
+  <!-- the targets to write to -->
+  <targets>
+    <target xsi:type="File" name="intacctfile" fileName="c:\temp\intacct-${shortdate}.log"
+            layout="${longdate}|${event-properties:item=EventId_Id}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}" />
+  </targets>
+
+  <!-- rules to map from logger name to target -->
+  <rules>
+    <logger name="Intacct" minlevel="Warn" writeTo="intacctfile" />
+  </rules>
+</nlog>

--- a/src/PE.Nominal.Web/PE.Nominal.Web.csproj
+++ b/src/PE.Nominal.Web/PE.Nominal.Web.csproj
@@ -25,6 +25,8 @@
     <PackageReference Include="Hangfire.Console" Version="1.3.10" />
     <PackageReference Include="HangFire.SqlServer" Version="1.6.17" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
+    <PackageReference Include="NLog" Version="4.5.3" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="4.5.2" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.4.0" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0" />
@@ -49,6 +51,12 @@
 
   <ItemGroup>
     <DotNetCliToolReference Include="pe.tsreflector" Version="1.0.9512" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="NLog.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 <PropertyGroup>

--- a/src/PE.Nominal.Web/Program.cs
+++ b/src/PE.Nominal.Web/Program.cs
@@ -14,12 +14,18 @@ namespace PE.Nominal.Web
     {
         public static void Main(string[] args)
         {
+            NLog.Web.NLogBuilder.ConfigureNLog("nlog.config");
             BuildWebHost(args).Run();
         }
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
+                .ConfigureLogging(logging =>
+                {
+                    logging.ClearProviders();
+                    logging.SetMinimumLevel(LogLevel.Trace);
+                })
                 .Build();
     }
 }

--- a/src/PE.Nominal.Web/Program.cs
+++ b/src/PE.Nominal.Web/Program.cs
@@ -21,8 +21,9 @@ namespace PE.Nominal.Web
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .ConfigureLogging(logging =>
+                .ConfigureLogging((hostingContext,logging) =>
                 {
+                    logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
                     logging.ClearProviders();
                     logging.SetMinimumLevel(LogLevel.Trace);
                 })

--- a/src/PE.Nominal.Web/appsettings.json
+++ b/src/PE.Nominal.Web/appsettings.json
@@ -5,7 +5,8 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Trace",
+      "Microsoft": "Information"
     }
   },
   "ReportService": {


### PR DESCRIPTION
This is wiring up the NLog support that Intacct has, to a custom log file (provided in NLog.config)
Updates to existing logging, and updated documentation on logging.